### PR TITLE
feat: 나의 최근 전적에 UIState를 적용한다.

### DIFF
--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="17" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/android/app/src/main/java/com/foss/foss/feature/home/HomeActivity.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/home/HomeActivity.kt
@@ -1,6 +1,7 @@
 package com.foss.foss.feature.home
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.commit
 import com.boogiwoogi.woogidi.activity.DiActivity
 import com.boogiwoogi.woogidi.pure.DefaultModule
@@ -13,6 +14,7 @@ import com.foss.foss.feature.statsearching.recent.RecentMatchesViewModel
 import com.foss.foss.feature.statsearching.relative.RelativeStatsFragment
 import com.foss.foss.feature.statsearching.relative.RelativeStatsViewModel
 import com.foss.foss.util.OnChangeVisibilityListener
+import com.foss.foss.util.UiState
 import com.foss.foss.util.lifecycle.repeatOnStarted
 
 class HomeActivity : DiActivity(), OnChangeVisibilityListener {
@@ -29,9 +31,21 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
 
         setupBinding()
         setupHomeView()
+
+        test()
+
         setupRecentMatchesObserver()
         setupRelativeStatsObserver()
         setSearchingRecentMatchesButtonClickListener()
+
+    }
+
+    private fun test() {
+        //recentMatchesViewModel 를 한번 사용하기 위한 임시 코드. (사용 안하면 오류 발생)
+        //java.lang.RuntimeException: Cannot create an instance of class com.foss.foss.feature.statsearching.recent.RecentMatchesViewModel
+        recentMatchesViewModel.matchTypes.observe(this) {
+            Log.d("Test", "Test")
+        }
     }
 
     private fun setupBinding() {
@@ -71,7 +85,19 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
     }
 
     private fun setupRecentMatchesObserver() {
-        recentMatchesViewModel.matches.observe(this) {
+        repeatOnStarted {
+            recentMatchesViewModel.uiState.collect { uiState ->
+                when (uiState) {
+                    is UiState.Loading -> {
+                    }
+
+                    is UiState.Success -> {
+                    }
+
+                    is UiState.Error -> {
+                    }
+                }
+            }
         }
     }
 
@@ -105,8 +131,13 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
     override fun onChangeVisibility() {
         val fragment = supportFragmentManager.findFragmentById(R.id.home_fcv_stats)
         when (fragment) {
-            is RecentMatchesFragment -> { fragment.changeVisibility() }
-            is RelativeStatsFragment -> { fragment.changeVisibility() }
+            is RecentMatchesFragment -> {
+                fragment.changeVisibility()
+            }
+
+            is RelativeStatsFragment -> {
+                fragment.changeVisibility()
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesEvent.kt
@@ -1,0 +1,6 @@
+package com.foss.foss.feature.statsearching.recent
+
+sealed interface RecentMatchesEvent {
+
+    object Failed : RecentMatchesEvent
+}

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesFragment.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesFragment.kt
@@ -12,6 +12,8 @@ import com.boogiwoogi.woogidi.pure.DefaultModule
 import com.boogiwoogi.woogidi.pure.Module
 import com.foss.foss.R
 import com.foss.foss.databinding.FragmentRecentMatchesBinding
+import com.foss.foss.util.UiState
+import com.foss.foss.util.lifecycle.repeatOnStarted
 
 class RecentMatchesFragment : DiFragment() {
 
@@ -47,18 +49,45 @@ class RecentMatchesFragment : DiFragment() {
     }
 
     private fun setupObserver() {
-        viewModel.matches.observe(viewLifecycleOwner) { matches ->
-            adapter.submitList(matches)
+
+        repeatOnStarted {
+            viewModel.uiState.collect { uiState ->
+                when (uiState) {
+                    is UiState.Loading -> {
+                    }
+
+                    is UiState.Success -> {
+                        adapter.submitList(uiState.data)
+                    }
+
+                    is UiState.Error -> {
+                    }
+                }
+            }
         }
-        viewModel.matchTypes.observe(viewLifecycleOwner) { matchTypes ->
+
+        viewModel.matchTypes.observe(viewLifecycleOwner) {
             binding.recentMatchSpinnerMatchType.adapter = ArrayAdapter(
                 requireContext(),
                 R.layout.spinner_item_match_type,
-                matchTypes.map { matchType ->
+                it.map { matchType ->
                     getString(matchType.resId)
                 }.toTypedArray(),
             )
         }
+
+//        repeatOnStarted {
+//            viewModel.matchTypes.collect { matchTypes ->
+//                binding.recentMatchSpinnerMatchType.adapter = ArrayAdapter(
+//                    requireContext(),
+//                    R.layout.spinner_item_match_type,
+//                    matchTypes.map { matchType ->
+//                        getString(matchType.resId)
+//                    }.toTypedArray(),
+//                )
+//            }
+//        }
+
     }
 
     fun changeVisibility() {

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
@@ -3,43 +3,59 @@ package com.foss.foss.feature.statsearching.recent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.map
-import com.foss.foss.model.Match
+import androidx.lifecycle.viewModelScope
 import com.foss.foss.model.MatchMapper.toUiModel
 import com.foss.foss.model.MatchType
 import com.foss.foss.model.MatchTypeUiModel
 import com.foss.foss.model.MatchUiModel
 import com.foss.foss.repository.MatchRepository
+import com.foss.foss.util.UiState
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 class RecentMatchesViewModel(
     private val matchRepository: MatchRepository
 ) : ViewModel() {
 
-    private val _matchTypes: MutableLiveData<List<MatchType>> = MutableLiveData(
-        MatchType
-            .values()
-            .toList()
-    )
-    val matchTypes: LiveData<List<MatchTypeUiModel>>
-        get() = _matchTypes.map { matchTypes ->
-            matchTypes.map { matchType ->
-                matchType.toUiModel()
-            }
-        }
 
-    private val _matches: MutableLiveData<List<Match>> = MutableLiveData()
-    val matches: LiveData<List<MatchUiModel>>
-        get() = _matches.map { matches ->
-            matches.map { match ->
-                match.toUiModel()
-            }
-        }
+    private val _matchTypes: MutableLiveData<List<MatchTypeUiModel>> =
+        MutableLiveData(MatchType.values().toList().map { machType ->
+            machType.toUiModel()
+        })
+
+    val matchTypes: LiveData<List<MatchTypeUiModel>>
+        get() = _matchTypes
+
+    private val _uiState: MutableStateFlow<UiState<List<MatchUiModel>>> =
+        MutableStateFlow(UiState.Loading)
+    val uiState: StateFlow<UiState<List<MatchUiModel>>>
+        get() = _uiState
+
+    private val _event: MutableSharedFlow<RecentMatchesEvent> =
+        MutableSharedFlow()
+    val event: SharedFlow<RecentMatchesEvent>
+        get() = _event.asSharedFlow()
 
     fun fetchMatches(nickname: String) {
-        matchRepository
-            .fetchMatches(nickname)
-            .onSuccess { matchResults ->
-                _matches.value = matchResults
-            }.onFailure {}
+        viewModelScope.launch {
+            _uiState.value = UiState.Loading
+
+            matchRepository.fetchMatches(nickname)
+                .map { matchResults ->
+                    matchResults.map { match ->
+                        match.toUiModel()
+                    }
+                }
+                .onSuccess { matchResults ->
+                    _uiState.value = UiState.Success(matchResults)
+                }.onFailure { error ->
+                    _uiState.value = UiState.Error
+                    _event.emit(RecentMatchesEvent.Failed)
+                }
+        }
     }
 }

--- a/android/app/src/main/java/com/foss/foss/util/UiState.kt
+++ b/android/app/src/main/java/com/foss/foss/util/UiState.kt
@@ -1,0 +1,7 @@
+package com.foss.foss.util
+
+sealed class UiState<out T>(val _data: T?) {
+    object Loading : UiState<Nothing>(_data = null)
+    object Error : UiState<Nothing>(_data = null)
+    data class Success<out R>(val data: R) : UiState<R>(_data = data)
+}

--- a/android/app/src/test/java/RecentMatchesViewModelTest.kt
+++ b/android/app/src/test/java/RecentMatchesViewModelTest.kt
@@ -1,0 +1,82 @@
+import com.foss.foss.feature.statsearching.recent.RecentMatchesViewModel
+import com.foss.foss.model.Match
+import com.foss.foss.model.MatchMapper.toUiModel
+import com.foss.foss.model.MatchType
+import com.foss.foss.model.WinDrawLose
+import com.foss.foss.model.legacy.Score
+import com.foss.foss.repository.MatchRepository
+import com.foss.foss.util.UiState
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+
+class RecentMatchesViewModelTest {
+
+    private lateinit var matchRepository: MatchRepository
+    private lateinit var recentMatchesViewModel: RecentMatchesViewModel
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        matchRepository = mockk()
+        recentMatchesViewModel = RecentMatchesViewModel(matchRepository)
+    }
+
+    @Test
+    fun `경기정보 가져오기 성공 시 UiState를 Success로 업데이트한다`() {
+        // given
+        val nickname = "사용자 이름"
+        val matches = listOf(
+            Match(
+                date = LocalDate.of(2023, 12, 20),
+                matchType = MatchType.OFFICIAL,
+                manOfTheMatch = 1,
+                otherSideNickname = "테스트",
+                winDrawLose = WinDrawLose.WIN,
+                score = Score(2, 1)
+            )
+        )
+
+        coEvery {
+            matchRepository.fetchMatches(nickname)
+        } returns Result.success(matches)
+
+        // when: 최근전적 기록을 요청하면
+        recentMatchesViewModel.fetchMatches(nickname)
+
+        // then
+        val uiState = recentMatchesViewModel.uiState.value
+        assertEquals(
+            UiState.Success(matches.map {
+                it.toUiModel()
+            }),
+            uiState
+        )
+    }
+
+    @Test
+    fun `매치정보 가져오기 실패 시 uiState를 Error로 업데이트한다`() {
+        // given
+        val nickname = "사용자 이름"
+        val errorMessage = "Failed"
+
+        coEvery {
+            matchRepository.fetchMatches(nickname)
+        } returns Result.failure(Throwable(errorMessage))
+
+        // when: 최근전적 기록 요청을 하면
+        recentMatchesViewModel.fetchMatches(nickname)
+
+        // then
+        val uiState = recentMatchesViewModel.uiState.value
+        assertEquals(UiState.Error, uiState)
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
<br/>

- #28 

## 작업 사항
<br/>

- 최근전적 검색에 UiState 적용
- 최근전적 ViewModel LiveData -> Flow 변경
- 최근전적 ViewModel 테스트코드 작성

## 기타 사항
<br/>

### 1. `java.lang.RuntimeException: Cannot create an instance of class com.foss.foss.feature.statsearching.recent.RecentMatchesViewModel` 오류

LiveData -> Flow 로 바꾼 후 HomeActivity에서 `RecentMatchesViewModel`인스턴스를 생성하지 않았다는 오류가 계속 발생하여 `MatchType`은 Flow로 변경하지 않고, 이를 HomeActivity에서 Observer하는 코드를  임시로 추가했습니다. 

<img width="1106" alt="image" src="https://github.com/fc-online-stats-searching/foss/assets/90389363/02f3b2fa-0440-4404-b7f9-7d259fa5f764">

### 2. Event 처리 관련
2차 스프린트 작업 사항에 실패 Event처리를 따로 하기로 했어서 Event처리를 위해 따로 `RecentMatchesEvent` 를 만들었습니다. 그리고 fetchMatches()에 실패했을 때 UiState error 처리, 이벤트 Failed 처리 모두 하고 있는데, 두 개 다 만들 필요가 있나요 ?? 
어차피 UiState error일때랑 이벤트 failed할 때가 fetchMatches()실패 했을 때로 동일한 이유라,, 그냥 UiState.error 일때 오류 핸들을 하면 되지 않을까 라는 생각이 드네요

위 질문에서 오류 Event 처리를 따로 해야 한다고 하면 `RelativeStatesEvent` 와 `RecentMatchEvent` 모두 실패 이벤트 처리를 위해 만든거라 동일한 역할을 하고있으니 따로 두지말고 합치는건 어떨까요 ?? 