### PR TITLE
refactor: Nickname 도메인 모델을 만든다.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,10 +45,6 @@ android {
         jvmTarget = '17'
     }
 
-    dataBinding {
-        enabled = true
-    }
-
     viewBinding {
         enabled = true
     }

--- a/android/app/src/main/java/com/foss/foss/data/FakeMatchRepository.kt
+++ b/android/app/src/main/java/com/foss/foss/data/FakeMatchRepository.kt
@@ -2,6 +2,7 @@ package com.foss.foss.data
 
 import com.foss.foss.model.Match
 import com.foss.foss.model.MatchType
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.legacy.Score
 import com.foss.foss.repository.MatchRepository
@@ -9,13 +10,13 @@ import java.time.LocalDate
 
 class FakeMatchRepository : MatchRepository {
 
-    override fun fetchMatches(nickname: String): Result<List<Match>> = runCatching { recentMatches }
+    override fun fetchMatches(nickname: Nickname): Result<List<Match>> = runCatching { recentMatches }
 
     override fun fetchMatchesBetweenUsers(
-        nickname: String,
-        opponentNickname: String,
+        nickname: Nickname,
+        opponentNickname: Nickname,
     ): Result<List<Match>> = runCatching {
-        recentMatches.filter { it.otherSideNickname == opponentNickname }
+        recentMatches.filter { it.otherSideNickname.name == opponentNickname.name }
     }
 
     companion object {
@@ -24,7 +25,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.WIN,
                 score = Score(point = 2, otherPoint = 1),
             ),
@@ -32,7 +33,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "신공학관캣대디",
+                otherSideNickname = Nickname("신공학관캣대디"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 1, otherPoint = 2),
             ),
@@ -40,7 +41,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.DRAW,
                 score = Score(point = 1, otherPoint = 1),
             ),
@@ -48,7 +49,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "신공학관캣대디",
+                otherSideNickname = Nickname("신공학관캣대디"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 1, otherPoint = 3),
             ),
@@ -56,7 +57,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.WIN,
                 score = Score(point = 5, otherPoint = 3),
             ),
@@ -64,7 +65,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 1, otherPoint = 6),
             ),
@@ -72,7 +73,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "신공학관캣맘",
+                otherSideNickname = Nickname("신공학관캣맘"),
                 winDrawLose = WinDrawLose.DRAW,
                 score = Score(point = 3, otherPoint = 3),
             ),
@@ -80,7 +81,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 2, otherPoint = 3),
             ),
@@ -88,7 +89,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "신공학관캣대디",
+                otherSideNickname = Nickname("신공학관캣대디"),
                 winDrawLose = WinDrawLose.WIN,
                 score = Score(point = 1, otherPoint = 0),
             ),
@@ -96,7 +97,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 2, otherPoint = 5),
             ),
@@ -104,7 +105,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "Clinton Hinton",
+                otherSideNickname = Nickname("Clinton Hinton"),
                 winDrawLose = WinDrawLose.DRAW,
                 score = Score(point = 3, otherPoint = 3),
             ),
@@ -112,7 +113,7 @@ class FakeMatchRepository : MatchRepository {
                 date = LocalDate.of(2023, 12, 2),
                 matchType = MatchType.OFFICIAL,
                 manOfTheMatch = 1,
-                otherSideNickname = "신공학관캣맘",
+                otherSideNickname = Nickname("신공학관캣맘"),
                 winDrawLose = WinDrawLose.LOSE,
                 score = Score(point = 0, otherPoint = 1),
             ),

--- a/android/app/src/main/java/com/foss/foss/data/FakeRelativeStatRepository.kt
+++ b/android/app/src/main/java/com/foss/foss/data/FakeRelativeStatRepository.kt
@@ -1,5 +1,6 @@
 package com.foss.foss.data
 
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.RelativeStat
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.WinDrawLoses
@@ -9,10 +10,10 @@ import java.time.LocalDate
 
 class FakeRelativeStatRepository : RelativeStatsRepository {
 
-    override fun fetchRelativeStats(nickname: String): Result<List<RelativeStat>> = runCatching {
+    override fun fetchRelativeStats(nickname: Nickname): Result<List<RelativeStat>> = runCatching {
         listOf(
             RelativeStat(
-                "Clinton Hinton",
+                Nickname("Clinton Hinton"),
                 recentMatchDate = LocalDate.of(2023, 12, 2),
                 winDrawLoses = WinDrawLoses(
                     listOf(
@@ -22,13 +23,13 @@ class FakeRelativeStatRepository : RelativeStatsRepository {
                         WinDrawLose.WIN,
                         WinDrawLose.DRAW,
                         WinDrawLose.WIN,
-                        WinDrawLose.DRAW
-                    )
+                        WinDrawLose.DRAW,
+                    ),
                 ),
-                totalScore = Score(point = 31, otherPoint = 23)
+                totalScore = Score(point = 31, otherPoint = 23),
             ),
             RelativeStat(
-                "신공학관캣대디",
+                Nickname("신공학관캣대디"),
                 recentMatchDate = LocalDate.of(2023, 12, 2),
                 winDrawLoses = WinDrawLoses(
                     listOf(
@@ -38,13 +39,13 @@ class FakeRelativeStatRepository : RelativeStatsRepository {
                         WinDrawLose.WIN,
                         WinDrawLose.DRAW,
                         WinDrawLose.WIN,
-                        WinDrawLose.DRAW
-                    )
+                        WinDrawLose.DRAW,
+                    ),
                 ),
-                totalScore = Score(point = 31, otherPoint = 23)
+                totalScore = Score(point = 31, otherPoint = 23),
             ),
             RelativeStat(
-                "신공학관캣맘",
+                Nickname("신공학관캣맘"),
                 recentMatchDate = LocalDate.of(2023, 12, 2),
                 winDrawLoses = WinDrawLoses(
                     listOf(
@@ -54,11 +55,11 @@ class FakeRelativeStatRepository : RelativeStatsRepository {
                         WinDrawLose.WIN,
                         WinDrawLose.DRAW,
                         WinDrawLose.WIN,
-                        WinDrawLose.DRAW
-                    )
+                        WinDrawLose.DRAW,
+                    ),
                 ),
-                totalScore = Score(point = 31, otherPoint = 23)
-            )
+                totalScore = Score(point = 31, otherPoint = 23),
+            ),
         )
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/home/HomeActivity.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/home/HomeActivity.kt
@@ -36,7 +36,6 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
 
     private fun setupBinding() {
         binding = ActivityHomeBinding.inflate(layoutInflater)
-        binding.viewModel = relativeStatsViewModel
 
         setContentView(binding.root)
     }
@@ -92,12 +91,13 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
     private fun setSearchingRecentMatchesButtonClickListener() {
         binding.homeIvFossLogo.setOnClickListener {
             recentMatchesViewModel.fetchMatches(binding.homeEtNicknameSearching.text.toString())
+            onChangeVisibility()
         }
     }
 
     private fun setSearchingRelativeStatsButtonClickListener() {
         binding.homeIvFossLogo.setOnClickListener {
-            relativeStatsViewModel.fetchRelativeStats()
+            relativeStatsViewModel.fetchRelativeStats(binding.homeEtNicknameSearching.text.toString())
             onChangeVisibility()
         }
     }
@@ -105,8 +105,8 @@ class HomeActivity : DiActivity(), OnChangeVisibilityListener {
     override fun onChangeVisibility() {
         val fragment = supportFragmentManager.findFragmentById(R.id.home_fcv_stats)
         when (fragment) {
-            is RecentMatchesFragment -> { fragment.changeVisibility() }
-            is RelativeStatsFragment -> { fragment.changeVisibility() }
+            is RecentMatchesFragment -> fragment.changeVisibility()
+            is RelativeStatsFragment -> fragment.changeVisibility()
         }
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesEvent.kt
@@ -1,0 +1,6 @@
+package com.foss.foss.feature.statsearching.recent
+
+sealed interface RecentMatchesEvent {
+
+    object Failed : RecentMatchesEvent
+}

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesFragment.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import com.boogiwoogi.woogidi.fragment.DiFragment
@@ -58,6 +59,17 @@ class RecentMatchesFragment : DiFragment() {
                     getString(matchType.resId)
                 }.toTypedArray(),
             )
+        }
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                RecentMatchesEvent.Failed -> {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.error_message_searching_failed),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
@@ -38,6 +38,10 @@ class RecentMatchesViewModel(
             }
         }
 
+    private val _event: MutableLiveData<RecentMatchesEvent> = MutableLiveData()
+    val event: LiveData<RecentMatchesEvent>
+        get() = _event
+
     fun fetchMatches(_nickname: String) {
         runCatching {
             val nickname = Nickname(_nickname)
@@ -47,6 +51,6 @@ class RecentMatchesViewModel(
                         _matches.value = matchResults
                     }.onFailure { }
             }
-        }.onFailure { }
+        }.onFailure { _event.value = RecentMatchesEvent.Failed }
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/recent/RecentMatchesViewModel.kt
@@ -4,21 +4,24 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
 import com.foss.foss.model.Match
 import com.foss.foss.model.MatchMapper.toUiModel
 import com.foss.foss.model.MatchType
 import com.foss.foss.model.MatchTypeUiModel
 import com.foss.foss.model.MatchUiModel
+import com.foss.foss.model.Nickname
 import com.foss.foss.repository.MatchRepository
+import kotlinx.coroutines.launch
 
 class RecentMatchesViewModel(
-    private val matchRepository: MatchRepository
+    private val matchRepository: MatchRepository,
 ) : ViewModel() {
 
     private val _matchTypes: MutableLiveData<List<MatchType>> = MutableLiveData(
         MatchType
             .values()
-            .toList()
+            .toList(),
     )
     val matchTypes: LiveData<List<MatchTypeUiModel>>
         get() = _matchTypes.map { matchTypes ->
@@ -35,11 +38,15 @@ class RecentMatchesViewModel(
             }
         }
 
-    fun fetchMatches(nickname: String) {
-        matchRepository
-            .fetchMatches(nickname)
-            .onSuccess { matchResults ->
-                _matches.value = matchResults
-            }.onFailure {}
+    fun fetchMatches(_nickname: String) {
+        runCatching {
+            val nickname = Nickname(_nickname)
+            viewModelScope.launch {
+                matchRepository.fetchMatches(nickname)
+                    .onSuccess { matchResults ->
+                        _matches.value = matchResults
+                    }.onFailure { }
+            }
+        }.onFailure { }
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/relative/RelativeStatsViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/relative/RelativeStatsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foss.foss.model.MatchMapper.toUiModel
 import com.foss.foss.model.MatchUiModel
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.RelativeStatMapper.toUiModel
 import com.foss.foss.model.RelativeStatUiModel
 import com.foss.foss.repository.MatchRepository
@@ -21,8 +22,8 @@ class RelativeStatsViewModel(
     private val relativeStatsRepository: RelativeStatsRepository,
 ) : ViewModel() {
 
-    val name = MutableStateFlow("")
-    private var _opponentName = ""
+    private lateinit var _nickname: Nickname
+    private lateinit var _opponentName: Nickname
 
     private val _relativeStats: MutableStateFlow<List<RelativeStatUiModel>> =
         MutableStateFlow(emptyList())
@@ -38,20 +39,23 @@ class RelativeStatsViewModel(
     val event: SharedFlow<RelativeStatsEvent>
         get() = _event.asSharedFlow()
 
-    fun fetchRelativeStats() {
-        viewModelScope.launch {
-            relativeStatsRepository.fetchRelativeStats(name.value)
-                .onSuccess { relativeStats ->
-                    _relativeStats.value = relativeStats.map { it.toUiModel() }
-                }.onFailure {
-                    _event.emit(RelativeStatsEvent.Failed)
-                }
-        }
+    fun fetchRelativeStats(nickname: String) {
+        runCatching {
+            _nickname = Nickname(nickname)
+            viewModelScope.launch {
+                relativeStatsRepository.fetchRelativeStats(_nickname)
+                    .onSuccess { relativeStats ->
+                        _relativeStats.value = relativeStats.map { it.toUiModel() }
+                    }.onFailure {
+                        _event.emit(RelativeStatsEvent.Failed)
+                    }
+            }
+        }.onFailure { }
     }
 
     fun fetchRelativeMatchesBetweenUsers() {
         viewModelScope.launch {
-            matchRepository.fetchMatchesBetweenUsers(name.value, _opponentName)
+            matchRepository.fetchMatchesBetweenUsers(_nickname, _opponentName)
                 .onSuccess { matches ->
                     _relativeStatsDetails.value = matches.map { it.toUiModel() }
                 }
@@ -64,6 +68,6 @@ class RelativeStatsViewModel(
     }
 
     fun updateOpponentName(opponentNickname: String) {
-        _opponentName = opponentNickname
+        _opponentName = Nickname(opponentNickname)
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/statsearching/relative/RelativeStatsViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/statsearching/relative/RelativeStatsViewModel.kt
@@ -50,6 +50,7 @@ class RelativeStatsViewModel(
                         _event.emit(RelativeStatsEvent.Failed)
                     }
             }
+            // TODO: UiState로 적용하면서 닉네임 변환 실패 시 처리 필요
         }.onFailure { }
     }
 

--- a/android/app/src/main/java/com/foss/foss/model/MatchMapper.kt
+++ b/android/app/src/main/java/com/foss/foss/model/MatchMapper.kt
@@ -6,10 +6,10 @@ object MatchMapper {
         date = date,
         manOfTheMatch = "https://fco.dn.nexoncdn.co.kr/live/externalAssets/common/players/p$manOfTheMatch.png",
         matchType = matchType.toUiModel(),
-        otherSideNickname = otherSideNickname,
+        otherSideNickname = otherSideNickname.name,
         winDrawLose = winDrawLose.toUiModel(),
         point = score.point,
-        otherPoint = score.otherPoint
+        otherPoint = score.otherPoint,
     )
 
     fun MatchType.toUiModel() = when (this) {

--- a/android/app/src/main/java/com/foss/foss/model/RelativeStatMapper.kt
+++ b/android/app/src/main/java/com/foss/foss/model/RelativeStatMapper.kt
@@ -3,13 +3,13 @@ package com.foss.foss.model
 object RelativeStatMapper {
 
     fun RelativeStat.toUiModel(): RelativeStatUiModel = RelativeStatUiModel(
-        opponentName = opponentName,
+        opponentName = opponentName.name,
         numberOfGames = winDrawLoses.numberOfGames,
         numberOfWins = winDrawLoses.numberOfWins,
         numberOfDraws = winDrawLoses.numberOfDraws,
         numberOfLoses = winDrawLoses.numberOfLoses,
         recentMatchDate = recentMatchDate,
         goal = totalScore.point,
-        conceded = totalScore.otherPoint
+        conceded = totalScore.otherPoint,
     )
 }

--- a/android/app/src/main/res/layout/activity_home.xml
+++ b/android/app/src/main/res/layout/activity_home.xml
@@ -1,66 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/common_dark_gray"
+    tools:context=".feature.home.HomeActivity">
 
-    <data>
+    <ImageView
+        android:id="@+id/home_iv_foss_logo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="12dp"
+        android:src="@drawable/ic_foss_logo"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <variable
-            name="viewModel"
-            type="com.foss.foss.feature.statsearching.relative.RelativeStatsViewModel" />
-    </data>
+    <EditText
+        android:id="@+id/home_et_nickname_searching"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_gray_10"
+        android:drawableStart="@drawable/ic_searching"
+        android:hint="@string/home_user_nickname_description"
+        android:padding="12dp"
+        android:textColor="@color/white"
+        android:textColorHint="#64686D"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/home_iv_foss_logo" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/common_dark_gray"
-        tools:context=".feature.home.HomeActivity">
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/home_fcv_stats"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/home_bnv_menu"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/home_et_nickname_searching" />
 
-        <ImageView
-            android:id="@+id/home_iv_foss_logo"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="12dp"
-            android:src="@drawable/ic_foss_logo"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/home_bnv_menu"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_gray_20_top"
+        app:itemIconTint="@color/selector_bottom_nav_item"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/home_bottom_nav_bar" />
 
-        <EditText
-            android:id="@+id/home_et_nickname_searching"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:background="@drawable/bg_gray_10"
-            android:drawableStart="@drawable/ic_searching"
-            android:hint="@string/home_user_nickname_description"
-            android:padding="12dp"
-            android:text="@={viewModel.name}"
-            android:textColor="@color/white"
-            android:textColorHint="#64686D"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/home_iv_foss_logo" />
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/home_fcv_stats"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/home_bnv_menu"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/home_et_nickname_searching" />
-
-        <com.google.android.material.bottomnavigation.BottomNavigationView
-            android:id="@+id/home_bnv_menu"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_gray_20_top"
-            app:itemIconTint="@color/selector_bottom_nav_item"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:menu="@menu/home_bottom_nav_bar" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -44,4 +44,7 @@
     <string name="item_relative_stats_conceded_title">실</string>
     <string name="home_user_nickname_description">사용자 이름</string>
     <string name="relative_stats_failed_fetching_data">상대 전적을 받아오지 못했습니다.</string>
+
+
+    <string name="toast_invalid_nickname_text">잘못된 닉네임입니다.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="previous">Previous</string>
 
 
-
     <string name="common_recent_stats">최근 전적</string>
     <string name="common_relative_stats">상대 전적</string>
     <string name="common_logo_description">FOSS</string>
@@ -31,7 +30,7 @@
     <string name="common_volta_offical_description">볼타 공식 경기</string>
     <string name="common_volta_custom_description">볼타 커스텀</string>
 
-
+    <string name="error_message_searching_failed">다시 검색해주세요.</string>
 
     <string name="item_match_result_score">%d:%d</string>
     <string name="item_match_man_of_the_match_description">MOM</string>
@@ -45,6 +44,4 @@
     <string name="home_user_nickname_description">사용자 이름</string>
     <string name="relative_stats_failed_fetching_data">상대 전적을 받아오지 못했습니다.</string>
 
-
-    <string name="toast_invalid_nickname_text">잘못된 닉네임입니다.</string>
 </resources>

--- a/android/app/src/test/java/MatchFixture.kt
+++ b/android/app/src/test/java/MatchFixture.kt
@@ -1,5 +1,6 @@
 import com.foss.foss.model.Match
 import com.foss.foss.model.MatchType
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.legacy.Score
 import java.time.LocalDate
@@ -10,7 +11,7 @@ object MatchFixture {
         Match(
             date = LocalDate.of(2023, 12, 18),
             matchType = MatchType.DIRECTOR,
-            otherSideNickname = "신공학관캣대디",
+            otherSideNickname = Nickname("신공학관캣대디"),
             manOfTheMatch = 1,
             winDrawLose = WinDrawLose.WIN,
             score = Score(point = 31, otherPoint = 23),

--- a/android/app/src/test/java/RelativeStatsFixture.kt
+++ b/android/app/src/test/java/RelativeStatsFixture.kt
@@ -1,3 +1,4 @@
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.RelativeStat
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.WinDrawLoses
@@ -8,7 +9,7 @@ object RelativeStatsFixture {
 
     fun create() = listOf(
         RelativeStat(
-            "Clinton Hinton",
+            Nickname("Clinton Hinton"),
             recentMatchDate = LocalDate.of(2023, 12, 2),
             winDrawLoses = WinDrawLoses(
                 listOf(
@@ -24,7 +25,7 @@ object RelativeStatsFixture {
             totalScore = Score(point = 31, otherPoint = 23),
         ),
         RelativeStat(
-            "신공학관캣대디",
+            Nickname("신공학관캣대디"),
             recentMatchDate = LocalDate.of(2023, 12, 2),
             winDrawLoses = WinDrawLoses(
                 listOf(
@@ -40,7 +41,7 @@ object RelativeStatsFixture {
             totalScore = Score(point = 31, otherPoint = 23),
         ),
         RelativeStat(
-            "신공학관캣맘",
+            Nickname("신공학관캣맘"),
             recentMatchDate = LocalDate.of(2023, 12, 2),
             winDrawLoses = WinDrawLoses(
                 listOf(

--- a/android/app/src/test/java/RelativeStatsViewModelTest.kt
+++ b/android/app/src/test/java/RelativeStatsViewModelTest.kt
@@ -54,8 +54,12 @@ class RelativeStatsViewModelTest {
         relativeStatsViewModel.fetchRelativeMatchesBetweenUsers()
     }
 
-    fun `상대전적 기록 요청을 하면`() {
-        relativeStatsViewModel.fetchRelativeStats()
+    fun `상대 전적 기록 요청을 하면`() {
+        relativeStatsViewModel.fetchRelativeStats("신공학관캣대디")
+    }
+
+    fun `상대방 닉네임을 초기화 하면`() {
+        relativeStatsViewModel.updateOpponentName("신공학관캣대디")
     }
 
     @Test
@@ -77,7 +81,7 @@ class RelativeStatsViewModelTest {
         `상대전적 기록 요청에 대한 결과가 다음과 같을 때`(Result.success(RelativeStatsFixture.create()))
 
         // when
-        `상대전적 기록 요청을 하면`()
+        `상대 전적 기록 요청을 하면`()
 
         val actual = relativeStatsViewModel.relativeStats.value
 
@@ -94,7 +98,7 @@ class RelativeStatsViewModelTest {
 
         relativeStatsViewModel.event.test {
             // when
-            `상대전적 기록 요청을 하면`()
+            `상대 전적 기록 요청을 하면`()
 
             val actual = awaitItem()
 
@@ -106,11 +110,13 @@ class RelativeStatsViewModelTest {
     }
 
     @Test
-    fun `특정 유저와의 상대 전적을 받아온 경우 빈 리스트가 아니다`() {
+    fun `상대 전적을 불러온 뒤 특정 유저와의 전적을 받아온 경우 빈 리스트가 아니다`() {
         // given
         `특정 유저와의 상대 전적 요청 결과가 다음과 같을 때`(Result.success(MatchFixture.create()))
 
         // when
+        `상대 전적 기록 요청을 하면`()
+        `상대방 닉네임을 초기화 하면`()
         `특정 유저와의 상대 전적 요청을 하면`()
 
         val actual = relativeStatsViewModel.relativeStatsDetails.value
@@ -127,6 +133,8 @@ class RelativeStatsViewModelTest {
         `특정 유저와의 상대 전적 요청 결과가 다음과 같을 때`(Result.success(MatchFixture.create()))
 
         // when
+        `상대 전적 기록 요청을 하면`()
+        `상대방 닉네임을 초기화 하면`()
         `특정 유저와의 상대 전적 요청을 하면`()
 
         val actual = relativeStatsViewModel.relativeStatsDetails.value

--- a/android/domain/src/main/java/com/foss/foss/model/Match.kt
+++ b/android/domain/src/main/java/com/foss/foss/model/Match.kt
@@ -7,7 +7,7 @@ data class Match(
     val date: LocalDate,
     val matchType: MatchType,
     val manOfTheMatch: Int,
-    val otherSideNickname: String,
+    val otherSideNickname: Nickname,
     val winDrawLose: WinDrawLose,
-    val score: Score
+    val score: Score,
 )

--- a/android/domain/src/main/java/com/foss/foss/model/Nickname.kt
+++ b/android/domain/src/main/java/com/foss/foss/model/Nickname.kt
@@ -1,0 +1,11 @@
+package com.foss.foss.model
+
+data class Nickname(val name: String) {
+    init {
+        require(name.isNotBlank()) { ERROR_BLACK }
+    }
+
+    companion object {
+        const val ERROR_BLACK = "닉네임은 공백일 수 없습니다."
+    }
+}

--- a/android/domain/src/main/java/com/foss/foss/model/RelativeStat.kt
+++ b/android/domain/src/main/java/com/foss/foss/model/RelativeStat.kt
@@ -7,8 +7,8 @@ import java.time.LocalDate
  * todo : opponentName으로 통일하기
  */
 data class RelativeStat(
-    val opponentName: String,
+    val opponentName: Nickname,
     val recentMatchDate: LocalDate,
     val winDrawLoses: WinDrawLoses,
-    val totalScore: Score
+    val totalScore: Score,
 )

--- a/android/domain/src/main/java/com/foss/foss/repository/MatchRepository.kt
+++ b/android/domain/src/main/java/com/foss/foss/repository/MatchRepository.kt
@@ -1,12 +1,13 @@
 package com.foss.foss.repository
 
 import com.foss.foss.model.Match
+import com.foss.foss.model.Nickname
 
 /**
  * todo: StatRepository로 이름 변경하기
  */
 interface MatchRepository {
 
-    fun fetchMatches(nickname: String): Result<List<Match>>
-    fun fetchMatchesBetweenUsers(nickname: String, opponentNickname: String): Result<List<Match>>
+    fun fetchMatches(nickname: Nickname): Result<List<Match>>
+    fun fetchMatchesBetweenUsers(nickname: Nickname, opponentNickname: Nickname): Result<List<Match>>
 }

--- a/android/domain/src/main/java/com/foss/foss/repository/RelativeStatsRepository.kt
+++ b/android/domain/src/main/java/com/foss/foss/repository/RelativeStatsRepository.kt
@@ -1,8 +1,9 @@
 package com.foss.foss.repository
 
+import com.foss.foss.model.Nickname
 import com.foss.foss.model.RelativeStat
 
 interface RelativeStatsRepository {
 
-    fun fetchRelativeStats(nickname: String): Result<List<RelativeStat>>
+    fun fetchRelativeStats(nickname: Nickname): Result<List<RelativeStat>>
 }


### PR DESCRIPTION
## 관련 이슈번호
- closed: #27 

<br/>

## 작업 사항
### Nickname 도메인 모델 생성
도메인 모델을 만들었는데, 현재는 공백만 불가능하도록 해두었습니다. 추후에 피파 닉네임 규정에 맞는 제한을 도메인 모델에 추가하면 좋을 것 같습니다.

### Toast 메시지
**RecentMatchesFragment**  
EditText에 있는 string을 뷰모델로 넘겨주고 뷰모델에서 해당 string을 Nickname 도메인 모델로 바꿉니다. 이 과정에서 exception이 발생하면 event를 Failed로 변경하여 뷰에서 감지하고 토스트를 띄울 수 있도록 했습니다.  

**RelativeStatsFragment**  
EditText에 있는 string을 뷰모델로 넘겨주고 뷰모델에서 해당 string을 Nickname 도메인 모델로 바꾸는 과정까지는 동일합니다.  
하지만 여기서 발생하는 exception을 viewModelScope 밖에서 runCatching으로 잡고있어서 `emit()`을 사용할 수 없더라구요.  
그래서 추후에 UiState를 도입한 뒤에 해당 부분도 처리하면 좋을 것 같다는 생각을 했습니다.

<br/>

## 기타 사항
현재 뷰모델에서 도메인 모델 Nickname을 사용하기 위해 runCatching으로 한 번 감싸주었는데요, 혹시 이보다 더 좋은 방법이 있을까요?  
코드가.. 맘에들지 않습니다.ㅠ

<br/>
