### PR TITLE
feat: 최근 전적에 대한 경기 결과를 날짜 별로 분류하는 View를 구성한다.

### DIFF
--- a/android/app/src/main/java/com/foss/foss/data/dto/RefreshDto.kt
+++ b/android/app/src/main/java/com/foss/foss/data/dto/RefreshDto.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RefreshDto(
-    @SerialName("success")
-    val success: Boolean,
-    @SerialName("code")
-    val code: Int,
-    @SerialName("msg")
-    val msg: String,
-    @SerialName("data")
-    val memberInfo: MemberInfoDto
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("level")
+    val level: Int,
+    @SerialName("renewal")
+    val renewal: String,
+    @SerialName("ouid")
+    val ouid: String
 )

--- a/android/app/src/main/java/com/foss/foss/design/FossProgressIndicator.kt
+++ b/android/app/src/main/java/com/foss/foss/design/FossProgressIndicator.kt
@@ -1,0 +1,25 @@
+package com.foss.foss.design
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FossProgressBar(){
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .width(28.dp)
+                .height(28.dp),
+            strokeWidth = 2.dp,
+            color = FossTheme.colors.fossGray700
+        )
+    }
+}

--- a/android/app/src/main/java/com/foss/foss/design/FossProgressIndicator.kt
+++ b/android/app/src/main/java/com/foss/foss/design/FossProgressIndicator.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun FossProgressBar(){
+fun FossProgressBar() {
     Box(modifier = Modifier.fillMaxSize()) {
         CircularProgressIndicator(
             modifier = Modifier

--- a/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
@@ -18,6 +18,7 @@ import com.foss.foss.feature.matchsearching.relativematch.navigation.navigateToR
 import com.foss.foss.feature.matchsearching.relativematch.navigation.relativeMatchNavGraph
 import kotlinx.coroutines.launch
 
+
 @Composable
 fun MainScreen(navigator: NavHostController = rememberNavController()) {
     val coroutineScope = rememberCoroutineScope()
@@ -44,11 +45,13 @@ fun MainScreen(navigator: NavHostController = rememberNavController()) {
 
             relativeMatchNavGraph(
                 onRelativeMatchClick = {},
-                onBackPressedClick = { navigator.popBackStack() }
+                onBackPressedClick = { navigator.popBackStack() },
+                onShowSnackBar = onShowSnackBar
             )
 
             recentMatchNavGraph(
-                onBackPressedClick = { navigator.popBackStack() }
+                onBackPressedClick = { navigator.popBackStack() },
+                onShowSnackBar = onShowSnackBar
             )
         }
         padding

--- a/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
@@ -18,7 +18,6 @@ import com.foss.foss.feature.matchsearching.relativematch.navigation.navigateToR
 import com.foss.foss.feature.matchsearching.relativematch.navigation.relativeMatchNavGraph
 import kotlinx.coroutines.launch
 
-
 @Composable
 fun MainScreen(navigator: NavHostController = rememberNavController()) {
     val coroutineScope = rememberCoroutineScope()

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchEvent.kt
@@ -2,7 +2,7 @@ package com.foss.foss.feature.matchsearching.recentmatch
 
 sealed interface RecentMatchEvent {
 
-    object None: RecentMatchEvent
+    object None : RecentMatchEvent
 
     object Failed : RecentMatchEvent
 

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchEvent.kt
@@ -2,6 +2,8 @@ package com.foss.foss.feature.matchsearching.recentmatch
 
 sealed interface RecentMatchEvent {
 
+    object None: RecentMatchEvent
+
     object Failed : RecentMatchEvent
 
     object RefreshFailed : RecentMatchEvent

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -63,11 +64,14 @@ import com.foss.foss.design.component.NicknameSearchingTextField
 import com.foss.foss.model.MatchMapper.toUiModel
 import com.foss.foss.model.MatchTypeUiModel
 import com.foss.foss.model.MatchUiModel
+import com.foss.foss.model.MatchesUiModel
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.WinDrawLoseUiModel
 import com.foss.foss.model.WinDrawLoseUiModel.Companion.getStringResId
 import com.foss.foss.util.MockData
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 @Composable
@@ -148,8 +152,8 @@ fun MatchColumn(
     when (uiState) {
         is RecentMatchUiState.RecentMatch -> {
             LazyColumn(modifier = modifier.fillMaxSize()) {
-                items(uiState.matches) { matchUiModel ->
-                    MatchItem(match = matchUiModel)
+                uiState.matches.forEach { matchesUiModel ->
+                    MatchesItem(matches = matchesUiModel)
                 }
             }
         }
@@ -157,6 +161,21 @@ fun MatchColumn(
         else -> {
             EmptyMatchText(modifier = modifier.fillMaxSize())
         }
+    }
+}
+
+fun LazyListScope.MatchesItem(
+    matches: MatchesUiModel,
+    modifier: Modifier = Modifier
+) {
+    item {
+        MatchDateText(
+            date = matches.date,
+            modifier = Modifier
+        )
+    }
+    items(matches.value) { matchUiModel ->
+        MatchItem(match = matchUiModel)
     }
 }
 
@@ -209,6 +228,27 @@ fun MatchItem(
             )
         }
     }
+}
+
+@Composable
+fun MatchDateText(
+    date: LocalDate,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        style = FossTheme.typography.body02,
+        color = FossTheme.colors.fossWt,
+        text = date.format(
+            DateTimeFormatter.ofPattern(
+                stringResource(R.string.item_recent_match_date_format)
+            )
+        ),
+        modifier = modifier.padding(
+            start = FossTheme.padding.BasicHorizontalPadding,
+            end = FossTheme.padding.BasicHorizontalPadding,
+            top = 8.dp
+        )
+    )
 }
 
 @Composable
@@ -484,16 +524,11 @@ fun getWinDrawLoseColor(winDrawLoseUiModel: WinDrawLoseUiModel): Color {
 
 @Preview(showBackground = true)
 @Composable
-fun MatchColumnPreview() {
-    MatchColumn(uiState = RecentMatchUiState.RecentMatch(MockData.recentMatch))
-}
-
-@Preview(showBackground = true)
-@Composable
 fun RecentMatchScreenPreview() {
     RecentMatchScreen(
-        uiState = RecentMatchUiState.Default,
+        uiState = RecentMatchUiState.RecentMatch(MockData.recentMatch),
         userName = "",
         selectedMatchType = MatchTypeUiModel.ALL
+
     )
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchUiState.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchUiState.kt
@@ -1,6 +1,6 @@
 package com.foss.foss.feature.matchsearching.recentmatch
 
-import com.foss.foss.model.MatchUiModel
+import com.foss.foss.model.MatchesUiModel
 
 sealed interface RecentMatchUiState {
 
@@ -10,5 +10,5 @@ sealed interface RecentMatchUiState {
 
     object Loading : RecentMatchUiState
 
-    data class RecentMatch(val matches: List<MatchUiModel>) : RecentMatchUiState
+    data class RecentMatch(val matches: List<MatchesUiModel>) : RecentMatchUiState
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchViewModel.kt
@@ -49,7 +49,7 @@ class RecentMatchViewModel @Inject constructor(
                 _uiState.value = RecentMatchUiState.Default
             }.map { matches ->
                 if (matches.isNotEmpty()) {
-                    RecentMatchUiState.RecentMatch(matches.map { it.toUiModel() })
+                    RecentMatchUiState.RecentMatch(matches.toUiModel())
                 } else {
                     RecentMatchUiState.Empty
                 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchViewModel.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/RecentMatchViewModel.kt
@@ -1,6 +1,5 @@
 package com.foss.foss.feature.matchsearching.recentmatch
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foss.foss.model.MatchMapper.toDomainModel
@@ -67,12 +66,10 @@ class RecentMatchViewModel @Inject constructor(
             }.onStart {
                 _uiState.value = RecentMatchUiState.Loading
             }.catch {
-                Log.d("woogi", "refreshMatches: $it")
                 _event.emit(RecentMatchEvent.RefreshFailed)
             }.onCompletion {
                 _uiState.value = RecentMatchUiState.Default
             }.collect {
-                Log.d("woogi", "refreshMatches: 성공")
                 _event.emit(RecentMatchEvent.RefreshSucceed)
             }
         }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/navigation/RecentMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/recentmatch/navigation/RecentMatchNavigation.kt
@@ -13,9 +13,13 @@ fun NavController.navigateToRecentMatch(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.recentMatchNavGraph(
-    onBackPressedClick: () -> Unit
+    onBackPressedClick: () -> Unit,
+    onShowSnackBar: (message: String) -> Unit
 ) {
     composable(route = RECENTMATCH_ROUTE) {
-        RecentMatchRoute(onBackPressedClick = onBackPressedClick)
+        RecentMatchRoute(
+            onBackPressedClick = onBackPressedClick,
+            onShowSnackBar = onShowSnackBar
+        )
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchEvent.kt
@@ -2,6 +2,8 @@ package com.foss.foss.feature.matchsearching.relativematch
 
 sealed interface RelativeMatchEvent {
 
+    object None: RelativeMatchEvent
+
     object Failed : RelativeMatchEvent
 
     object RefreshFailed : RelativeMatchEvent

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchEvent.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchEvent.kt
@@ -2,7 +2,7 @@ package com.foss.foss.feature.matchsearching.relativematch
 
 sealed interface RelativeMatchEvent {
 
-    object None: RelativeMatchEvent
+    object None : RelativeMatchEvent
 
     object Failed : RelativeMatchEvent
 

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
@@ -47,7 +47,6 @@ import com.foss.foss.design.FossTheme
 import com.foss.foss.design.component.EmptyMatchText
 import com.foss.foss.design.component.FossTopBar
 import com.foss.foss.design.component.NicknameSearchingTextField
-import com.foss.foss.feature.matchsearching.recentmatch.RecentMatchEvent
 import com.foss.foss.model.RelativeMatchUiModel
 import com.foss.foss.util.MockRelativeMatchData
 

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -40,10 +42,12 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.foss.foss.R
+import com.foss.foss.design.FossProgressBar
 import com.foss.foss.design.FossTheme
 import com.foss.foss.design.component.EmptyMatchText
 import com.foss.foss.design.component.FossTopBar
 import com.foss.foss.design.component.NicknameSearchingTextField
+import com.foss.foss.feature.matchsearching.recentmatch.RecentMatchEvent
 import com.foss.foss.model.RelativeMatchUiModel
 import com.foss.foss.util.MockRelativeMatchData
 
@@ -51,12 +55,29 @@ import com.foss.foss.util.MockRelativeMatchData
 fun RelativeMatchRoute(
     onRelativeMatchClick: (relativeMatch: RelativeMatchUiModel) -> Unit,
     onBackPressedClick: () -> Unit,
+    onShowSnackBar: (message: String) -> Unit,
     modifier: Modifier = Modifier,
     relativeMatchViewModel: RelativeMatchViewModel = hiltViewModel()
 ) {
     val uiState by relativeMatchViewModel.uiState.collectAsStateWithLifecycle()
     var userName by remember { mutableStateOf("") }
+    val context = LocalContext.current
 
+    LaunchedEffect(key1 = null) {
+        relativeMatchViewModel.event.collect { uiEvent ->
+            when (uiEvent) {
+                is RelativeMatchEvent.RefreshFailed -> {
+                    onShowSnackBar(context.getString(R.string.common_refresh_failed_message))
+                }
+
+                is RelativeMatchEvent.RefreshSucceed -> {
+                    onShowSnackBar(context.getString(R.string.common_refresh_succeed_message))
+                }
+
+                else -> {}
+            }
+        }
+    }
     RelativeMatchScreen(
         uiState = uiState,
         userName = userName,
@@ -148,9 +169,10 @@ fun RelativeMatchColumn(
                 }
             }
         }
-        else -> {
-            EmptyMatchText(modifier = modifier.fillMaxSize())
-        }
+
+        is RelativeMatchUiState.Loading -> FossProgressBar()
+
+        else -> EmptyMatchText(modifier = modifier.fillMaxSize())
     }
 }
 

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
@@ -15,11 +15,13 @@ fun NavController.navigateToRelativeMatch(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.relativeMatchNavGraph(
     onRelativeMatchClick: (RelativeMatchUiModel) -> Unit,
+    onShowSnackBar: (message: String) -> Unit,
     onBackPressedClick: () -> Unit
 ) {
     composable(route = RELATIVEMATCH_ROUTE) {
         RelativeMatchRoute(
             onRelativeMatchClick = onRelativeMatchClick,
+            onShowSnackBar = onShowSnackBar,
             onBackPressedClick = onBackPressedClick
         )
     }

--- a/android/app/src/main/java/com/foss/foss/model/MatchMapper.kt
+++ b/android/app/src/main/java/com/foss/foss/model/MatchMapper.kt
@@ -1,6 +1,31 @@
 package com.foss.foss.model
 
+import java.time.LocalDate
+
 object MatchMapper {
+
+    /**
+     * Match를 날짜 별로 정리해 MatchesUiModel로 mapping한다.
+     * RecentScreen을 위한 mapping 함수
+     */
+    fun List<Match>.toUiModel(): List<MatchesUiModel> {
+        val matches: MutableMap<LocalDate, ArrayList<Match>> = mutableMapOf()
+
+        forEach { match ->
+            if (!matches.containsKey(match.date.toLocalDate())) matches[match.date.toLocalDate()] = arrayListOf()
+            matches[match.date.toLocalDate()]?.add(match)
+        }
+        return matches.map {
+            MatchesUiModel(
+                date = it.key,
+                value = it.value.map { match ->
+                    match.toUiModel()
+                }
+            )
+        }.sortedByDescending { matchesUiModel ->
+            matchesUiModel.date
+        }
+    }
 
     fun Match.toUiModel() = MatchUiModel(
         date = date,

--- a/android/app/src/main/java/com/foss/foss/model/MatchesUiModel.kt
+++ b/android/app/src/main/java/com/foss/foss/model/MatchesUiModel.kt
@@ -1,0 +1,11 @@
+package com.foss.foss.model
+
+import java.time.LocalDate
+
+/**
+ * 날짜별로 경기 기록을 모으기 위한 data class
+ */
+data class MatchesUiModel(
+    val date: LocalDate,
+    val value: List<MatchUiModel>
+)

--- a/android/app/src/main/java/com/foss/foss/util/MockData.kt
+++ b/android/app/src/main/java/com/foss/foss/util/MockData.kt
@@ -1,8 +1,11 @@
 package com.foss.foss.util
 
-import com.foss.foss.model.MatchTypeUiModel
-import com.foss.foss.model.MatchUiModel
-import com.foss.foss.model.WinDrawLoseUiModel
+import com.foss.foss.model.Match
+import com.foss.foss.model.MatchMapper.toUiModel
+import com.foss.foss.model.MatchType
+import com.foss.foss.model.MatchesUiModel
+import com.foss.foss.model.Score
+import com.foss.foss.model.WinDrawLose
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -14,69 +17,83 @@ object MockData {
 
     private val now = LocalDateTime.parse(nnow, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))
 
-    val recentMatch = listOf<MatchUiModel>(
-        MatchUiModel(
+    val recentMatch: List<MatchesUiModel> = listOf(
+        Match(
             date = now.minusMinutes(30),
-            matchType = MatchTypeUiModel.OFFICIAL,
+            matchType = MatchType.OFFICIAL,
             manOfTheMatch = null,
             opponentName = "신공학관캣맘",
-            winDrawLose = WinDrawLoseUiModel.WIN,
-            point = 1,
-            otherPoint = 0
+            winDrawLose = WinDrawLose.WIN,
+            Score(
+                point = 1,
+                otherPoint = 0
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusHours(1),
-            matchType = MatchTypeUiModel.OFFICIAL,
+            matchType = MatchType.OFFICIAL,
             manOfTheMatch = null,
             opponentName = "신공학관캣맘",
-            winDrawLose = WinDrawLoseUiModel.WIN,
-            point = 1,
-            otherPoint = 0
+            winDrawLose = WinDrawLose.WIN,
+            Score(
+                point = 1,
+                otherPoint = 0
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusHours(2),
-            matchType = MatchTypeUiModel.OFFICIAL,
+            matchType = MatchType.OFFICIAL,
             manOfTheMatch = null,
             opponentName = "똥찔긴형",
-            winDrawLose = WinDrawLoseUiModel.LOSE,
-            point = 0,
-            otherPoint = 1
+            winDrawLose = WinDrawLose.LOSE,
+            Score(
+                point = 0,
+                otherPoint = 1
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusHours(23).minusMinutes(59),
-            matchType = MatchTypeUiModel.OFFICIAL,
+            matchType = MatchType.OFFICIAL,
             manOfTheMatch = null,
             opponentName = "신공학관캣맘",
-            winDrawLose = WinDrawLoseUiModel.WIN,
-            point = 1,
-            otherPoint = 0
+            winDrawLose = WinDrawLose.WIN,
+            Score(
+                point = 1,
+                otherPoint = 0
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusDays(1),
-            matchType = MatchTypeUiModel.CLASSIC_ONE_TO_ONE,
+            matchType = MatchType.CLASSIC_ONE_TO_ONE,
             manOfTheMatch = null,
             opponentName = "똥찔긴형",
-            winDrawLose = WinDrawLoseUiModel.LOSE,
-            point = 0,
-            otherPoint = 1
+            winDrawLose = WinDrawLose.LOSE,
+            Score(
+                point = 0,
+                otherPoint = 1
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusDays(2),
-            matchType = MatchTypeUiModel.CLASSIC_ONE_TO_ONE,
+            matchType = MatchType.CLASSIC_ONE_TO_ONE,
             manOfTheMatch = null,
             opponentName = "똥찔긴형",
-            winDrawLose = WinDrawLoseUiModel.LOSE,
-            point = 0,
-            otherPoint = 1
+            winDrawLose = WinDrawLose.LOSE,
+            Score(
+                point = 0,
+                otherPoint = 1
+            )
         ),
-        MatchUiModel(
+        Match(
             date = now.minusDays(3),
-            matchType = MatchTypeUiModel.CLASSIC_ONE_TO_ONE,
+            matchType = MatchType.CLASSIC_ONE_TO_ONE,
             manOfTheMatch = null,
             opponentName = "똥찔긴형",
-            winDrawLose = WinDrawLoseUiModel.LOSE,
-            point = 0,
-            otherPoint = 1
+            winDrawLose = WinDrawLose.LOSE,
+            Score(
+                point = 0,
+                otherPoint = 1
+            )
         )
-    )
+    ).toUiModel()
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="common_request_searching_nickname">사용자 이름을 검색해 주세요.</string>
     <string name="common_empty_match">전적을 검색해보세요!</string>
     <string name="common_refresh_failed_message">전적 갱신에 실패했습니다.</string>
-    <string name="common_refresh_succeed_message">전적 갱신에 성공했습니다. \n전적을 검색해보세요!</string>
+    <string name="common_refresh_succeed_message">전적 갱신에 성공했습니다. 전적을 검색해보세요!</string>
     <string name="common_failed_fetching_matches">전적 검색에 실패했습니다. \n닉네임을 확인해주세요.</string>
     <string name="common_empty_matches">최근 기록된 전적이 없습니다.</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -61,4 +61,6 @@
     <string name="item_relative_match_total_result">%d전 %d승 %d무 %d패</string>
     <string name="item_relative_match_total_gain_loss">득 %d / 실 %d</string>
     <string name="item_recent_match_date_format">yyyy년 MM월 dd일</string>
+    <string name="common_operation_failed_message">닉네임 혹은 네트워크 상태를 확인해주세요.</string>
+    <string name="common_refresh_succeed">갱신에 성공했습니다! 전적을 검색해보세요.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
     <string name="item_relative_match_minute_after_latest_match">최근 경기 15분 전</string>
     <string name="item_relative_match_total_result">%d전 %d승 %d무 %d패</string>
     <string name="item_relative_match_total_gain_loss">득 %d / 실 %d</string>
+    <string name="item_recent_match_date_format">yyyy년 MM월 dd일</string>
 </resources>

--- a/android/app/src/test/java/RecentMatchViewModelTest.kt
+++ b/android/app/src/test/java/RecentMatchViewModelTest.kt
@@ -78,7 +78,7 @@ class RecentMatchViewModelTest {
         val actual = recentMatchViewModel.uiState.value
 
         // then
-        val expected = RecentMatchUiState.RecentMatch(matches.map { it.toUiModel() })
+        val expected = RecentMatchUiState.RecentMatch(matches.toUiModel())
 
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
## 관련 이슈번호
- #70 

## 작업 사항
최근 전적에 대한 경기 결과를 날짜 별로 분류하는 View를 구성

## 기타 사항
![image](https://github.com/fc-online-stats-searching/foss/assets/88770426/c5f50a64-d26e-46f9-ab33-6636c024f24e)