### PR TITLE
feat: 상대 전적 화면에서 세부 전적으로 넘어가는 로직을 만든다.

### DIFF
--- a/android/app/src/main/java/com/foss/foss/data/mapper/RelativeMatchDtoMapper.kt
+++ b/android/app/src/main/java/com/foss/foss/data/mapper/RelativeMatchDtoMapper.kt
@@ -6,18 +6,31 @@ import com.foss.foss.model.RelativeMatch
 import com.foss.foss.model.Score
 import com.foss.foss.model.WinDrawLose
 import com.foss.foss.model.WinDrawLoses
+import java.time.DateTimeException
 
 object RelativeMatchDtoMapper {
 
     private val commonDtoMapper = CommonDtoMapper()
 
-    fun RelativeMatchDTO.toDomainModel(nickname: String): RelativeMatch = RelativeMatch(
-        opponentName = opponentNickname,
-        recentMatchDate = commonDtoMapper.mapToDate(lastDate),
-        winDrawLoses = WinDrawLoses(mapToWinDrawLoses(win, tie, lose)),
-        totalScore = Score(gain, loss),
-        matchDetails = matchResponse.map { it.toDomainModel(nickname) }
-    )
+    fun RelativeMatchDTO.toDomainModel(nickname: String): RelativeMatch {
+        val opponentName = opponentNickname
+        val recentMatchDate = try {
+            commonDtoMapper.mapToDate(lastDate)
+        } catch (e: DateTimeException) {
+            null
+        }
+        val winDrawLoses = WinDrawLoses(mapToWinDrawLoses(win, tie, lose))
+        val totalScore = Score(gain, loss)
+        val matchDetails = matchResponse.map { it.toDomainModel(nickname) }
+
+        return RelativeMatch(
+            opponentName = opponentName,
+            recentMatchDate = recentMatchDate,
+            winDrawLoses = winDrawLoses,
+            totalScore = totalScore,
+            matchDetails = matchDetails
+        )
+    }
 
     private fun mapToWinDrawLoses(win: Int, tie: Int, lose: Int): List<WinDrawLose> {
         return List(win) { WinDrawLose.WIN } + List(tie) { WinDrawLose.DRAW } + List(lose) { WinDrawLose.LOSE }

--- a/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
@@ -14,6 +14,8 @@ import com.foss.foss.feature.home.navigation.HOME_ROUTE
 import com.foss.foss.feature.home.navigation.homeNavGraph
 import com.foss.foss.feature.matchsearching.recentmatch.navigation.navigateToRecentMatch
 import com.foss.foss.feature.matchsearching.recentmatch.navigation.recentMatchNavGraph
+import com.foss.foss.feature.matchsearching.relativematch.detail.navigation.detailRelativeMatchNavGraph
+import com.foss.foss.feature.matchsearching.relativematch.detail.navigation.navigateToDetailRelativeMatch
 import com.foss.foss.feature.matchsearching.relativematch.navigation.navigateToRelativeMatch
 import com.foss.foss.feature.matchsearching.relativematch.navigation.relativeMatchNavGraph
 import kotlinx.coroutines.launch
@@ -43,7 +45,9 @@ fun MainScreen(navigator: NavHostController = rememberNavController()) {
             )
 
             relativeMatchNavGraph(
-                onRelativeMatchClick = {},
+                onRelativeMatchClick = { relativeMatch ->
+                    navigator.navigateToDetailRelativeMatch(relativeMatch)
+                },
                 onBackPressedClick = { navigator.popBackStack() },
                 onShowSnackBar = onShowSnackBar
             )
@@ -51,6 +55,11 @@ fun MainScreen(navigator: NavHostController = rememberNavController()) {
             recentMatchNavGraph(
                 onBackPressedClick = { navigator.popBackStack() },
                 onShowSnackBar = onShowSnackBar
+            )
+
+            detailRelativeMatchNavGraph(
+                navController = navigator,
+                onBackPressedClick = { navigator.popBackStack() }
             )
         }
         padding

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
@@ -49,6 +49,8 @@ import com.foss.foss.design.component.FossTopBar
 import com.foss.foss.design.component.NicknameSearchingTextField
 import com.foss.foss.model.RelativeMatchUiModel
 import com.foss.foss.util.MockRelativeMatchData
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Composable
 fun RelativeMatchRoute(
@@ -308,6 +310,34 @@ fun RelativeMatchWinRate(
     }
 }
 
+fun calculateRecentMatchTime(relativeMatchUiModel: RelativeMatchUiModel): String? {
+    val matchDetails = relativeMatchUiModel.matchDetails
+    if (matchDetails.isEmpty()) {
+        return null
+    }
+
+    val recentMatchTime = matchDetails.maxByOrNull { it.date }?.date
+    val currentTime = LocalDateTime.now()
+
+    if (recentMatchTime == null) {
+        return null
+    }
+
+    val difference = ChronoUnit.MINUTES.between(recentMatchTime, currentTime)
+
+    val days = difference / (60 * 24)
+    val hours = (difference % (60 * 24)) / 60
+    val minutes = difference % 60
+
+    return when {
+        days > 1 -> "${days}일 ${hours}시간 ${minutes}분 전"
+        days == 1L -> "1일 ${hours}시간 ${minutes}분 전"
+        hours > 1 -> "${hours}시간 ${minutes}분 전"
+        hours == 1L -> "1시간 ${minutes}분 전"
+        else -> "${minutes}분 전"
+    }
+}
+
 @Composable
 fun RelativeMatchOpponentData(
     relativeMatch: RelativeMatchUiModel,
@@ -330,7 +360,7 @@ fun RelativeMatchOpponentData(
         Text(
             style = FossTheme.typography.caption02,
             color = FossTheme.colors.fossGray100,
-            text = stringResource(R.string.item_relative_match_minute_after_latest_match)
+            text = "${calculateRecentMatchTime(relativeMatch)}"
         )
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchScreen.kt
@@ -47,6 +47,8 @@ import com.foss.foss.design.FossTheme
 import com.foss.foss.design.component.EmptyMatchText
 import com.foss.foss.design.component.FossTopBar
 import com.foss.foss.design.component.NicknameSearchingTextField
+import com.foss.foss.model.MatchesUiModel
+import com.foss.foss.model.RelativeMatchMapper.toMatchesUiModel
 import com.foss.foss.model.RelativeMatchUiModel
 import com.foss.foss.util.MockRelativeMatchData
 import java.time.LocalDateTime
@@ -54,7 +56,7 @@ import java.time.temporal.ChronoUnit
 
 @Composable
 fun RelativeMatchRoute(
-    onRelativeMatchClick: (relativeMatch: RelativeMatchUiModel) -> Unit,
+    onRelativeMatchClick: (matchesUiModels: List<MatchesUiModel>) -> Unit,
     onBackPressedClick: () -> Unit,
     onShowSnackBar: (message: String) -> Unit,
     modifier: Modifier = Modifier,
@@ -96,7 +98,7 @@ fun RelativeMatchScreen(
     uiState: RelativeMatchUiState,
     userName: String,
     modifier: Modifier = Modifier,
-    onRelativeMatchClick: (relativeMatch: RelativeMatchUiModel) -> Unit = {},
+    onRelativeMatchClick: (matchesUiModels: List<MatchesUiModel>) -> Unit = {},
     onBackPressedClick: () -> Unit = {},
     onRefreshClick: () -> Unit = {},
     onSearch: () -> Unit = {},
@@ -130,8 +132,8 @@ fun RelativeMatchScreen(
             Surface(color = colorResource(id = R.color.foss_bk)) {
                 RelativeMatchColumn(
                     uiState = uiState,
-                    onRelativeMatchClicked = { relativeMatch ->
-                        onRelativeMatchClick(relativeMatch)
+                    onRelativeMatchClicked = { matches ->
+                        onRelativeMatchClick(matches)
                     }
                 )
             }
@@ -142,7 +144,7 @@ fun RelativeMatchScreen(
 @Composable
 fun RelativeMatchColumn(
     uiState: RelativeMatchUiState,
-    onRelativeMatchClicked: (RelativeMatchUiModel) -> Unit,
+    onRelativeMatchClicked: (List<MatchesUiModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (uiState) {
@@ -164,6 +166,7 @@ fun RelativeMatchColumn(
                     items(uiState.relativeMatches) { match ->
                         RelativeMatchItem(
                             relativeMatch = match,
+                            matchesUiModels = match.matchDetails.toMatchesUiModel(),
                             onRelativeMatchClick = onRelativeMatchClicked
                         )
                     }
@@ -180,7 +183,8 @@ fun RelativeMatchColumn(
 @Composable
 fun RelativeMatchItem(
     relativeMatch: RelativeMatchUiModel,
-    onRelativeMatchClick: (RelativeMatchUiModel) -> Unit,
+    matchesUiModels: List<MatchesUiModel>,
+    onRelativeMatchClick: (List<MatchesUiModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val winRate = getWinRate(relativeMatch)
@@ -223,6 +227,7 @@ fun RelativeMatchItem(
             )
             RelativeMatchTotalResult(
                 relativeMatch = relativeMatch,
+                matchesUiModels = matchesUiModels,
                 onRelativeMatchClick = onRelativeMatchClick
             )
             Spacer(Modifier.width(8.dp))
@@ -303,7 +308,10 @@ fun RelativeMatchWinRate(
             Text(
                 style = FossTheme.typography.caption03,
                 color = FossTheme.colors.fossWt,
-                text = String.format(stringResource(R.string.item_relative_match_win_rate), winRate),
+                text = String.format(
+                    stringResource(R.string.item_relative_match_win_rate),
+                    winRate
+                ),
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             )
         }
@@ -368,7 +376,8 @@ fun RelativeMatchOpponentData(
 @Composable
 fun RelativeMatchTotalResult(
     relativeMatch: RelativeMatchUiModel,
-    onRelativeMatchClick: (relativeMatch: RelativeMatchUiModel) -> Unit,
+    matchesUiModels: List<MatchesUiModel>,
+    onRelativeMatchClick: (matchesUiModels: List<MatchesUiModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(horizontalAlignment = Alignment.End, modifier = Modifier.padding(end = 5.dp)) {
@@ -399,7 +408,7 @@ fun RelativeMatchTotalResult(
             modifier = Modifier
                 .size(16.dp)
                 .clickable {
-                    onRelativeMatchClick(relativeMatch)
+                    onRelativeMatchClick(matchesUiModels)
                 }
         )
     }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/DetailRelativeMatchRoute.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/DetailRelativeMatchRoute.kt
@@ -1,0 +1,84 @@
+package com.foss.foss.feature.matchsearching.relativematch.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.foss.foss.design.FossTheme
+import com.foss.foss.design.component.FossTopBar
+import com.foss.foss.feature.matchsearching.recentmatch.MatchTypeSpinner
+import com.foss.foss.feature.matchsearching.recentmatch.MatchesItem
+import com.foss.foss.model.MatchTypeUiModel
+import com.foss.foss.model.MatchesUiModel
+
+@Composable
+fun DetailRelativeMatchRoute(
+    matchesUiModels: List<MatchesUiModel>,
+    onBackPressedClick: () -> Unit = {}
+) {
+    var selectedMatchType by remember { mutableStateOf(MatchTypeUiModel.entries.first()) }
+
+    DetailRelativeMatchScreen(
+        matchesUiModels = matchesUiModels,
+        onBackPressedClick = onBackPressedClick,
+        onSelectionChanged = { selectedMatchType = it },
+        selectedMatchType = selectedMatchType
+    )
+}
+
+@Composable
+fun DetailRelativeMatchScreen(
+    matchesUiModels: List<MatchesUiModel>,
+    onBackPressedClick: () -> Unit = {},
+    onRefreshClick: () -> Unit = {},
+    onSelectionChanged: (MatchTypeUiModel) -> Unit = {},
+    selectedMatchType: MatchTypeUiModel
+) {
+    val title =
+        if (matchesUiModels.isNotEmpty()) matchesUiModels[0].value[0].opponentName else "뒤로가기"
+
+    Scaffold(
+        topBar = {
+            FossTopBar(
+                title = title,
+                onBackPressedClick = onBackPressedClick,
+                onRefreshClick = onRefreshClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .background(FossTheme.colors.fossBk)
+        ) {
+            MatchTypeSpinner(
+                selected = selectedMatchType,
+                matchTypes = MatchTypeUiModel.entries,
+                onSelectionChanged = onSelectionChanged,
+                modifier = Modifier.padding(top = 18.dp, end = 20.dp)
+            )
+            DetailMatchColumn(matchesUiModels = matchesUiModels)
+        }
+    }
+}
+
+@Composable
+fun DetailMatchColumn(
+    matchesUiModels: List<MatchesUiModel>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        matchesUiModels.forEach { matchesUiModel ->
+            MatchesItem(matches = matchesUiModel)
+        }
+    }
+}

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/navigation/DetailRelativeMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/navigation/DetailRelativeMatchNavigation.kt
@@ -1,0 +1,35 @@
+package com.foss.foss.feature.matchsearching.relativematch.detail.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.foss.foss.feature.matchsearching.relativematch.detail.DetailRelativeMatchRoute
+import com.foss.foss.model.MatchesUiModel
+
+const val DETAILRELATIVEMATCH_ROUTE = "DETAILRELATIVEMATCH"
+
+fun NavController.navigateToDetailRelativeMatch(
+    matchesUiModels: List<MatchesUiModel>,
+    navOptions: NavOptions? = null
+) {
+    currentBackStackEntry?.savedStateHandle?.set("relativeMatch", matchesUiModels)
+    navigate(DETAILRELATIVEMATCH_ROUTE, navOptions)
+}
+
+fun NavGraphBuilder.detailRelativeMatchNavGraph(
+    navController: NavController,
+    onBackPressedClick: () -> Unit
+) {
+    composable(route = DETAILRELATIVEMATCH_ROUTE) {
+        val data =
+            navController.previousBackStackEntry?.savedStateHandle?.get<List<MatchesUiModel>>(
+                "relativeMatch"
+            )
+        if (data != null) {
+            DetailRelativeMatchRoute(matchesUiModels = data, onBackPressedClick = onBackPressedClick)
+        } else {
+            DetailRelativeMatchRoute(matchesUiModels = emptyList(), onBackPressedClick = onBackPressedClick)
+        }
+    }
+}

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.foss.foss.feature.matchsearching.relativematch.RelativeMatchRoute
-import com.foss.foss.model.RelativeMatchUiModel
+import com.foss.foss.model.MatchesUiModel
 
 const val RELATIVEMATCH_ROUTE = "RELATIVEMATCH"
 
@@ -14,7 +14,7 @@ fun NavController.navigateToRelativeMatch(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.relativeMatchNavGraph(
-    onRelativeMatchClick: (RelativeMatchUiModel) -> Unit,
+    onRelativeMatchClick: (List<MatchesUiModel>) -> Unit,
     onShowSnackBar: (message: String) -> Unit,
     onBackPressedClick: () -> Unit
 ) {

--- a/android/app/src/main/java/com/foss/foss/model/RelativeMatchMapper.kt
+++ b/android/app/src/main/java/com/foss/foss/model/RelativeMatchMapper.kt
@@ -1,6 +1,7 @@
 package com.foss.foss.model
 
 import com.foss.foss.model.MatchMapper.toUiModel
+import java.time.LocalDate
 
 object RelativeMatchMapper {
 
@@ -15,4 +16,22 @@ object RelativeMatchMapper {
         conceded = totalScore.otherPoint,
         matchDetails = matchDetails.map { it.toUiModel() }
     )
+
+    fun List<MatchUiModel>.toMatchesUiModel(): List<MatchesUiModel> {
+        val matches: MutableMap<LocalDate, ArrayList<MatchUiModel>> = mutableMapOf()
+
+        forEach { match ->
+            if (!matches.containsKey(match.date.toLocalDate())) matches[match.date.toLocalDate()] = arrayListOf()
+            matches[match.date.toLocalDate()]?.add(match)
+        }
+
+        return matches.map {
+            MatchesUiModel(
+                date = it.key,
+                value = it.value
+            )
+        }.sortedByDescending { matchesUiModel ->
+            matchesUiModel.date
+        }
+    }
 }

--- a/android/app/src/main/java/com/foss/foss/model/RelativeMatchUiModel.kt
+++ b/android/app/src/main/java/com/foss/foss/model/RelativeMatchUiModel.kt
@@ -8,7 +8,7 @@ data class RelativeMatchUiModel(
     val numberOfWins: Int,
     val numberOfDraws: Int,
     val numberOfLoses: Int,
-    val recentMatchDate: LocalDate,
+    val recentMatchDate: LocalDate?,
     val goal: Int,
     val conceded: Int,
     val matchDetails: List<MatchUiModel>

--- a/android/domain/src/main/java/com/foss/foss/model/RelativeMatch.kt
+++ b/android/domain/src/main/java/com/foss/foss/model/RelativeMatch.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class RelativeMatch(
     val opponentName: String,
-    val recentMatchDate: LocalDate,
+    val recentMatchDate: LocalDate?,
     val winDrawLoses: WinDrawLoses,
     val totalScore: Score,
     val matchDetails: List<Match>


### PR DESCRIPTION
## 관련 이슈번호
<br/>

- #77 

## 작업 사항
<br/>

- DetailRelativeScreen 구성 및 그에 따른 navigation 정의
- onRelativeMatchClick 인자 RelativeMatchUiModel -> List<MatchesUiModel> 로 변경 (최근 전적 컴포저블 함수 재사용 위함)
- List<MatchUiModel>.toMatchesUiModel() 매퍼 생성 (최근 전적 컴포저블 함수 재사용 위함)

## 기타 사항
<br/>

- 디테일 → 뒤로가기 그냥하면 nullpoint오류 발생 그래서 우선은 널 값을 받을 때는 빈 리스트 주는 걸로 해놓았습니다.
  ```kotlin
      composable(route = DETAILRELATIVEMATCH_ROUTE) {
          val data =
              navController.previousBackStackEntry?.savedStateHandle?.get<List<MatchesUiModel>>(
                  "relativeMatch"
              )
          if (data != null) {
              DetailRelativeMatchRoute(matchesUiModels = data, onBackPressedClick = onBackPressedClick)
          } else {
              DetailRelativeMatchRoute(matchesUiModels = emptyList(),onBackPressedClick = onBackPressedClick)
          }
      }
  ```

  popupbackStack()을 하면 백스택에서 detailRelativeRoute를 제거를 하고 이전에 있는 화면으로 가는건데, 지금 저 로직으로 돌아간다는 거는 popupbackStack()을 하면 한번 더 detailRelativeRoute 을 렌더링 하고 뒤로 간다는건데 원래 popupbackStack() 을 하면 화면을 한번 더 렌더링 하고 스택에서 제거하나요 ?

  DetailRelativeMatchScreen에서 아래 부분도 위 문제에 맞춰서 임시로 해놓았는데 앱을 동작시켜서 뒤로 가기를 해보면 뒤로가기 화살표 옆에 지금 설정해 놓은 “뒤로가기” 가 떴다가 사라집니다. DetailRelativeScreen을 한번 더 렌더링 하는게 맞는 것 같습니다. 여기에 대해서 아시는 분 있으신가요 ?

  ```kotlin
   val title =
          if (matchesUiModels.isNotEmpty()) matchesUiModels[0].value[0].opponentName else "뒤로가기"
  ```

- DetailRelativeMatch 와 RecentMatch 화면이 거의 동일하여 겹치는 컴포저블 함수들이 대부분인데 해당 함수들 추후에 따로 분리하여 재사용할 수 있도록 해야할 것 같습니다