### PR TITLE
fix: 상대전적 세부 화면으로 갈 때 recomposition이 불필요하게 일어나는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/main/MainScreen.kt
@@ -21,7 +21,7 @@ import com.foss.foss.feature.matchsearching.relativematch.navigation.relativeMat
 import kotlinx.coroutines.launch
 
 @Composable
-fun MainScreen(navigator: NavHostController = rememberNavController()) {
+fun MainScreen(navController: NavHostController = rememberNavController()) {
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState: SnackbarHostState = remember { SnackbarHostState() }
     val onShowSnackBar: (message: String) -> Unit = { message ->
@@ -35,31 +35,29 @@ fun MainScreen(navigator: NavHostController = rememberNavController()) {
         snackbarHost = { SnackbarHost(snackBarHostState) }
     ) { padding ->
         NavHost(
-            navController = navigator,
+            navController = navController,
             startDestination = HOME_ROUTE
         ) {
             homeNavGraph(
-                onRelativeStatButtonClick = { navigator.navigateToRelativeMatch() },
-                onRecentStatButtonClick = { navigator.navigateToRecentMatch() },
+                onRelativeStatButtonClick = { navController.navigateToRelativeMatch() },
+                onRecentStatButtonClick = { navController.navigateToRecentMatch() },
                 onShowSnackBar = onShowSnackBar
             )
 
             relativeMatchNavGraph(
-                onRelativeMatchClick = { relativeMatch ->
-                    navigator.navigateToDetailRelativeMatch(relativeMatch)
-                },
-                onBackPressedClick = { navigator.popBackStack() },
+                onRelativeMatchClick = { navController.navigateToDetailRelativeMatch() },
+                onBackPressedClick = { navController.popBackStack() },
                 onShowSnackBar = onShowSnackBar
             )
 
             recentMatchNavGraph(
-                onBackPressedClick = { navigator.popBackStack() },
+                onBackPressedClick = { navController.popBackStack() },
                 onShowSnackBar = onShowSnackBar
             )
 
             detailRelativeMatchNavGraph(
-                navController = navigator,
-                onBackPressedClick = { navigator.popBackStack() }
+                navController = navController,
+                onBackPressedClick = { navController.popBackStack() }
             )
         }
         padding

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchUiState.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/RelativeMatchUiState.kt
@@ -1,5 +1,7 @@
 package com.foss.foss.feature.matchsearching.relativematch
 
+import com.foss.foss.model.MatchesUiModel
+import com.foss.foss.model.RelativeMatchMapper.toMatchesUiModel
 import com.foss.foss.model.RelativeMatchUiModel
 
 sealed interface RelativeMatchUiState {
@@ -10,6 +12,27 @@ sealed interface RelativeMatchUiState {
 
     object Loading : RelativeMatchUiState
 
-    data class RelativeMatches(val relativeMatches: List<RelativeMatchUiModel>) :
-        RelativeMatchUiState
+    data class RelativeMatches(
+        val relativeMatches: List<RelativeMatchUiModel>
+    ) : RelativeMatchUiState {
+
+        var opponentName: String = ""
+            private set
+        var showingMatchDetails: List<MatchesUiModel> = listOf()
+            private set
+
+        fun updateShowingMatchDetails(opponentNickname: String) {
+            opponentName = opponentNickname
+            showingMatchDetails =
+                relativeMatches.find { it.opponentName == opponentName }
+                    ?.matchDetails
+                    ?.toMatchesUiModel()
+                    ?: throw NoSuchElementException(UPDATE_SHOWING_MATCH_DETAILS_ERROR)
+        }
+    }
+
+    companion object {
+
+        private const val UPDATE_SHOWING_MATCH_DETAILS_ERROR = "해당 닉네임을 가진 유저와의 상대전적을 찾을 수 없습니다."
+    }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/navigation/DetailRelativeMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/detail/navigation/DetailRelativeMatchNavigation.kt
@@ -1,35 +1,33 @@
 package com.foss.foss.feature.matchsearching.relativematch.detail.navigation
 
+import android.annotation.SuppressLint
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.foss.foss.feature.matchsearching.relativematch.RelativeMatchViewModel
 import com.foss.foss.feature.matchsearching.relativematch.detail.DetailRelativeMatchRoute
-import com.foss.foss.model.MatchesUiModel
+import com.foss.foss.feature.matchsearching.relativematch.navigation.RELATIVEMATCH_ROUTE
 
 const val DETAILRELATIVEMATCH_ROUTE = "DETAILRELATIVEMATCH"
 
-fun NavController.navigateToDetailRelativeMatch(
-    matchesUiModels: List<MatchesUiModel>,
-    navOptions: NavOptions? = null
-) {
-    currentBackStackEntry?.savedStateHandle?.set("relativeMatch", matchesUiModels)
+fun NavController.navigateToDetailRelativeMatch(navOptions: NavOptions? = null) {
     navigate(DETAILRELATIVEMATCH_ROUTE, navOptions)
 }
 
+@SuppressLint("UnrememberedGetBackStackEntry")
 fun NavGraphBuilder.detailRelativeMatchNavGraph(
     navController: NavController,
     onBackPressedClick: () -> Unit
 ) {
     composable(route = DETAILRELATIVEMATCH_ROUTE) {
-        val data =
-            navController.previousBackStackEntry?.savedStateHandle?.get<List<MatchesUiModel>>(
-                "relativeMatch"
-            )
-        if (data != null) {
-            DetailRelativeMatchRoute(matchesUiModels = data, onBackPressedClick = onBackPressedClick)
-        } else {
-            DetailRelativeMatchRoute(matchesUiModels = emptyList(), onBackPressedClick = onBackPressedClick)
+        val sharedViewModel = navController.getBackStackEntry(RELATIVEMATCH_ROUTE).run {
+            hiltViewModel<RelativeMatchViewModel>(this)
         }
+        DetailRelativeMatchRoute(
+            relativeMatchViewModel = sharedViewModel,
+            onBackPressedClick = onBackPressedClick
+        )
     }
 }

--- a/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
+++ b/android/app/src/main/java/com/foss/foss/feature/matchsearching/relativematch/navigation/RelativeMatchNavigation.kt
@@ -5,7 +5,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.foss.foss.feature.matchsearching.relativematch.RelativeMatchRoute
-import com.foss.foss.model.MatchesUiModel
 
 const val RELATIVEMATCH_ROUTE = "RELATIVEMATCH"
 
@@ -14,7 +13,7 @@ fun NavController.navigateToRelativeMatch(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.relativeMatchNavGraph(
-    onRelativeMatchClick: (List<MatchesUiModel>) -> Unit,
+    onRelativeMatchClick: () -> Unit,
     onShowSnackBar: (message: String) -> Unit,
     onBackPressedClick: () -> Unit
 ) {

--- a/android/app/src/main/java/com/foss/foss/util/TimeUtil.kt
+++ b/android/app/src/main/java/com/foss/foss/util/TimeUtil.kt
@@ -1,0 +1,33 @@
+package com.foss.foss.util
+
+import com.foss.foss.model.RelativeMatchUiModel
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+fun calculateRecentMatchTime(relativeMatchUiModel: RelativeMatchUiModel): String? {
+    val matchDetails = relativeMatchUiModel.matchDetails
+    if (matchDetails.isEmpty()) {
+        return null
+    }
+
+    val recentMatchTime = matchDetails.maxByOrNull { it.date }?.date
+    val currentTime = LocalDateTime.now()
+
+    if (recentMatchTime == null) {
+        return null
+    }
+
+    val difference = ChronoUnit.MINUTES.between(recentMatchTime, currentTime)
+
+    val days = difference / (60 * 24)
+    val hours = (difference % (60 * 24)) / 60
+    val minutes = difference % 60
+
+    return when {
+        days > 1 -> "${days}일 ${hours}시간 ${minutes}분 전"
+        days == 1L -> "1일 ${hours}시간 ${minutes}분 전"
+        hours > 1 -> "${hours}시간 ${minutes}분 전"
+        hours == 1L -> "1시간 ${minutes}분 전"
+        else -> "${minutes}분 전"
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
- #84

## 작업 사항
ViewModel을 공유함으로써 bundle로 넘겨줄 때 발생하던 오류를 해결했습니다. 코드 부분에 설명 달아놓겠습니다!
<br/>

## 기타 사항
[Screen_recording_20240405_025448.webm](https://github.com/fc-online-stats-searching/foss/assets/88770426/23ee9b88-fd71-48be-906c-5c415f466e3b)
<br/>
